### PR TITLE
Tentatively adds header checking for REST API

### DIFF
--- a/src/nodeMCU_REST/TextDisplay_Rest_Adapter/platformio.ini
+++ b/src/nodeMCU_REST/TextDisplay_Rest_Adapter/platformio.ini
@@ -33,6 +33,8 @@ monitor_speed = 115200
 board_build.filesystem = littlefs
 build_flags = 
 	-D TEXTECKE_ESP32 -D LOGGER_LEVEL=LOGGER_LEVEL_ALL  -D ENABLE_DATABASE_LOGGING -D USE_OAUTH=1
+	; Uncomment the following line to enable authorization header checking
+	; -D ENABLE_AUTHORIZATION
 
 
 [env:texteck-esp32-zam]
@@ -47,3 +49,5 @@ monitor_speed = 115200
 board_build.filesystem = littlefs
 build_flags = 
 	-D TEXTECKE_ESP32 -D PROD -D LOGGER_LEVEL=LOGGER_LEVEL_OFF -D ENABLE_DATABASE_LOGGING -D USE_OAUTH=1
+	; Uncomment the following line to enable authorization header checking
+	; -D ENABLE_AUTHORIZATION

--- a/src/nodeMCU_REST/TextDisplay_Rest_Adapter/src/main.cpp
+++ b/src/nodeMCU_REST/TextDisplay_Rest_Adapter/src/main.cpp
@@ -516,13 +516,8 @@ void handle_post_form_request(AsyncWebServerRequest *request)
 {
   LOG_DEBUG_LN("handle_post_form_request: Received HTTP POST texteck request");
   
-  #ifdef ENABLE_AUTHORIZATION
-  // Check authorization before processing
-  if (!isAuthorized(request)) {
-    sendUnauthorized(request);
-    return;
-  }
-  #endif
+  // Note: Authorization check removed for HTML form submission
+  // The HTML UI is embedded in firmware and cannot pass Authorization headers
   
   if (request->method() != HTTP_POST) {
     request->send(405, "text/plain", "Method Not Allowed");

--- a/src/nodeMCU_REST/TextDisplay_Rest_Adapter/src/main.cpp
+++ b/src/nodeMCU_REST/TextDisplay_Rest_Adapter/src/main.cpp
@@ -71,6 +71,60 @@ enum EventType {
   EVENT_COLOR_LOG
 };
 
+// ==================== AUTHORIZATION MIDDLEWARE ====================
+#ifdef ENABLE_AUTHORIZATION
+/**
+ * @brief Validates the Authorization header for incoming requests
+ * 
+ * Checks if the request contains a valid Bearer token in the Authorization header.
+ * Expected format: "Authorization: Bearer <token>"
+ * 
+ * @param request The incoming HTTP request
+ * @return true if authorization is valid or not required, false otherwise
+ */
+bool isAuthorized(AsyncWebServerRequest *request) {
+  // Check if Authorization header exists
+  if (!request->hasHeader("Authorization")) {
+    LOG_INFO_LN("Authorization failed: No Authorization header present");
+    return false;
+  }
+  
+  String authHeader = request->header("Authorization");
+  LOG_DEBUG_F("Authorization header: %s\n", authHeader.c_str());
+  
+  // Expected format: "Bearer <token>"
+  if (!authHeader.startsWith("Bearer ")) {
+    LOG_INFO_LN("Authorization failed: Invalid format (missing 'Bearer ')");
+    return false;
+  }
+  
+  // Extract token (skip "Bearer " prefix)
+  String token = authHeader.substring(7);
+  token.trim(); // Remove any leading/trailing whitespace
+  
+  // Compare with configured token
+  String expectedToken = String(AUTHORIZATION_TOKEN);
+  if (token != expectedToken) {
+    LOG_INFO_F("Authorization failed: Invalid token (got: %s)\n", token.c_str());
+    return false;
+  }
+  
+  LOG_DEBUG_LN("Authorization successful");
+  return true;
+}
+
+/**
+ * @brief Sends an unauthorized response to the client
+ * 
+ * @param request The incoming HTTP request to respond to
+ */
+void sendUnauthorized(AsyncWebServerRequest *request) {
+  request->send(401, "application/json; charset=utf-8", 
+                "{\"error\":\"Unauthorized - Valid Bearer token required\"}");
+}
+#endif
+// ==================== END AUTHORIZATION MIDDLEWARE ====================
+
 struct DatabaseEvent {
   EventType type;
   char message[MESSAGE_BUFFER_SIZE];
@@ -461,6 +515,15 @@ void render_and_send(const char* action, const char *param) {
 void handle_post_form_request(AsyncWebServerRequest *request)
 {
   LOG_DEBUG_LN("handle_post_form_request: Received HTTP POST texteck request");
+  
+  #ifdef ENABLE_AUTHORIZATION
+  // Check authorization before processing
+  if (!isAuthorized(request)) {
+    sendUnauthorized(request);
+    return;
+  }
+  #endif
+  
   if (request->method() != HTTP_POST) {
     request->send(405, "text/plain", "Method Not Allowed");
   } else {
@@ -720,7 +783,17 @@ void setup_rest_api()
     },
     NULL,
     [](AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
-      LOG_INFO_LN("Received REST POST message request");      
+      LOG_INFO_LN("Received REST POST message request");
+      
+      #ifdef ENABLE_AUTHORIZATION
+      // Check authorization on first chunk
+      if (index == 0 && !isAuthorized(request)) {
+        sendUnauthorized(request);
+        postBodyBuffer.erase(request);
+        return;
+      }
+      #endif
+      
       std::string &buf = postBodyBuffer[request];
       if (index == 0) buf.clear();
       buf.append((const char *)data, len);
@@ -751,6 +824,14 @@ void setup_rest_api()
     // GET endpoint: return the current message as JSON
     server.on("/api/v1/message", HTTP_GET, [](AsyncWebServerRequest *request) {
       LOG_INFO_LN("Received REST GET message request");
+      
+      #ifdef ENABLE_AUTHORIZATION
+      if (!isAuthorized(request)) {
+        sendUnauthorized(request);
+        return;
+      }
+      #endif
+      
       String response;
       DynamicJsonDocument doc(512);
       doc["message"] = current_message;
@@ -767,6 +848,16 @@ void setup_rest_api()
       NULL,
       [](AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
         LOG_INFO_LN("Received REST POST color request");
+        
+        #ifdef ENABLE_AUTHORIZATION
+        // Check authorization on first chunk
+        if (index == 0 && !isAuthorized(request)) {
+          sendUnauthorized(request);
+          postBodyBuffer.erase(request);
+          return;
+        }
+        #endif
+        
         std::string &buf = postBodyBuffer[request];
         if (index == 0) buf.clear();
         buf.append((const char *)data, len);
@@ -829,6 +920,14 @@ void setup_rest_api()
     // GET /api/v1/color - return current fg/bg
     server.on("/api/v1/color", HTTP_GET, [](AsyncWebServerRequest *request) {
       LOG_INFO_LN("Received REST GET color request");
+      
+      #ifdef ENABLE_AUTHORIZATION
+      if (!isAuthorized(request)) {
+        sendUnauthorized(request);
+        return;
+      }
+      #endif
+      
       String response;
       DynamicJsonDocument doc(256);
       doc["fg"] = foreground;


### PR DESCRIPTION
This was an attempt to secure the endpoints but it is not really possible while the HTML is served from the ESP32 without implementing TLS inside which is not where I wanted to go with this. A small demo feature for checking an Authorization header for a bearer token was added as an experiment but not intended for practical use.